### PR TITLE
Add `add-py-typed` option which puts a `py.typed` marker in the installed package

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ steps:
 | `install-command` | The command to install the package. This command should install the package in the current directory.                                                                                        | No       | `pip install . -U`       |
 | `python-version`  | Python version to use. See [actions/setup-python](https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#using-the-python-version-input) for more information              | No       | `3.x`                    |
 | `pyright-version` | Pyright version to use. Must be a valid version specifier for pip install, see [`pip` user guide](https://packaging.python.org/en/latest/specifications/version-specifiers/#id5) for details | No       | latest available version |
+| `add-py-typed`    | Add a `py.typed` marker to the package specified by `package-name` post-installation. Useful for packages that shouldn't have one as part of their standard installation just yet.           | No       | false                    |
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,10 @@ inputs:
   package-name:
     description: The name of the package to check.
     required: true
+  add-py-typed:
+    description: Add a `py.typed` marker to the package specified by `package-name` post-installation. Useful for packages that shouldn't have one as part of their standard installation just yet.
+    required: false
+    default: false
 outputs:
   base-completeness-score:
     description: The type completeness score of the base branch.
@@ -30,7 +34,6 @@ runs:
   using: composite
   steps:
     - uses: actions/checkout@v4
-
     # https://github.com/actions/checkout/issues/329#issuecomment-674881489
     - run: git fetch --depth=1
       shell: bash
@@ -45,20 +48,40 @@ runs:
       run: |
         python -W ignore -m pip install pyright${{ inputs.pyright-version }}
 
-    - name: Get PR Completeness
+    # Must run before base completeness, as base completeness will check out the base branch
+    # and we can't go back to the PR branch after that in case the PR is coming from a fork
+    - name: Install PR version
       shell: bash
-      # Must run before base completeness, as base completeness will check out the base branch
-      # and we can't go back to the PR branch after that in case the PR is coming from a fork
       run: |
         ${{ inputs.install-command }}
+
+    - name: Add py.typed marker to installed package
+      if: ${{ fromJSON(inputs.add-py-typed) == true }}
+      shell: bash
+      run: |
+        python3 ${{ github.action_path }}/add-py-typed-marker.py ${{ inputs.package-name }}
+
+    - name: Get PR Completeness
+      shell: bash
+      run: |
         pyright --verifytypes ${{ inputs.package-name }} --ignoreexternal --outputjson > pr.json || true
         pyright --verifytypes ${{ inputs.package-name }} --ignoreexternal > pr.readable || true
 
-    - name: Get Base Completeness
+    - name: Install Base version
       shell: bash
       run: |
         git checkout ${{ github.base_ref }}
         ${{ inputs.install-command }}
+
+    - name: Add py.typed marker to installed package
+      if: ${{ fromJSON(inputs.add-py-typed) == true }}
+      shell: bash
+      run: |
+        python3 ${{ github.action_path }}/add-py-typed-marker.py ${{ inputs.package-name }}
+
+    - name: Get Base Completeness
+      shell: bash
+      run: |
         pyright --verifytypes ${{ inputs.package-name }} --ignoreexternal --outputjson > base.json || true
         pyright --verifytypes ${{ inputs.package-name }} --ignoreexternal > base.readable || true
 

--- a/add-py-typed-marker.py
+++ b/add-py-typed-marker.py
@@ -1,0 +1,27 @@
+"""
+Add a py.typed marker to the package specified as the first command-line arg.
+"""
+from importlib.util import find_spec
+from pathlib import Path
+from sys import argv
+
+package_name = argv[1]
+spec = find_spec(package_name)
+package_dirs = spec.submodule_search_locations
+
+if len(package_dirs) < 1:
+  raise RuntimeError(
+    f"Could not find installed location of package {package_name}."
+  )
+if len(package_dirs) > 1:
+  raise RuntimeError(
+    f"Found more than one location for package {package_name}. "
+    "It's not currently clear how to handle this, so please file an issue "
+    "with pyright-type-completeness explaining what you were trying to do "
+    "and what you think should happen."
+  )
+
+package_dir = package_dirs[0]
+
+(Path(package_dir) / "py.typed").touch()
+print(f"Added py.typed to {package_dir}.")


### PR DESCRIPTION
This PR implements approach 2.ii from https://github.com/Bibo-Joshi/pyright-type-completeness/issues/5#issuecomment-2366812746.

Because the script to figure out the package installation directory & add `py.typed` to it needs to be run twice, I decided to put it into its own `.py` file and reference it via [`github.action-path`](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context) instead of running it inline via `jannekem/run-python-script-action` like the existing Python script in the Action. At a later point, it might make sense to turn this into an Action of its own and depend on it here (e.g. if Mypy gets a similar type completeness checking feature).

You can see that it works here:
- https://github.com/smheidrich/rope/pull/2

And see that the old behavior if `add-py-typed` is omitted still works as before (if a `py.typed` marker is present in the actual repo) here:
- https://github.com/smheidrich/rope/pull/3

Fixes #5