### PR TITLE
Add `py-typed-dir` option which puts a `py.typed` marker in the specified directory pre-installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ steps:
 | `install-command` | The command to install the package. This command should install the package in the current directory.                                                                                        | No       | `pip install . -U`       |
 | `python-version`  | Python version to use. See [actions/setup-python](https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#using-the-python-version-input) for more information              | No       | `3.x`                    |
 | `pyright-version` | Pyright version to use. Must be a valid version specifier for pip install, see [`pip` user guide](https://packaging.python.org/en/latest/specifications/version-specifiers/#id5) for details | No       | latest available version |
+| `py-typed-dir`    | If not empty, add a `py.typed` marker to this directory prior to installation.                                                                                                               | No       | `''` (empty)             |
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,10 @@ inputs:
   package-name:
     description: The name of the package to check.
     required: true
+  py-typed-dir:
+    description: If not empty, add a `py.typed` marker to this directory prior to installation.
+    required: false
+    default: ''
 outputs:
   base-completeness-score:
     description: The type completeness score of the base branch.
@@ -45,6 +49,12 @@ runs:
       run: |
         python -W ignore -m pip install pyright${{ inputs.pyright-version }}
 
+    - name: Add py.typed marker
+      if: ${{ inputs.py-typed-dir != '' }}
+      shell: bash
+      run: |
+        touch ${{ inputs.py-typed-dir }}/py.typed
+
     - name: Get PR Completeness
       shell: bash
       # Must run before base completeness, as base completeness will check out the base branch
@@ -53,6 +63,12 @@ runs:
         ${{ inputs.install-command }}
         pyright --verifytypes ${{ inputs.package-name }} --ignoreexternal --outputjson > pr.json || true
         pyright --verifytypes ${{ inputs.package-name }} --ignoreexternal > pr.readable || true
+
+    - name: Add py.typed marker
+      if: ${{ inputs.py-typed-dir != '' }}
+      shell: bash
+      run: |
+        touch ${{ inputs.py-typed-dir }}/py.typed
 
     - name: Get Base Completeness
       shell: bash


### PR DESCRIPTION
This PR implements the approach from https://github.com/Bibo-Joshi/pyright-type-completeness/issues/5#issuecomment-2365127301

Not tested yet.